### PR TITLE
Display palette correctly

### DIFF
--- a/TileMap.cpp
+++ b/TileMap.cpp
@@ -216,7 +216,10 @@ int TPalette::render(int xpos,int ypos){
 
 	for(int i = 0; i < 16; i++){
 		for(int j = 0; j < 16; j++){
-			PixelAreas[(i*16)+j] = TPixels[(i*16)+j]->render(xpos + ((mGlobalSettings.TileSize*mGlobalSettings.PaletteScale+2)*i), ypos + ((mGlobalSettings.TileSize*mGlobalSettings.PaletteScale+2)*j), mGlobalSettings.PaletteScale,true,true);
+			PixelAreas[(i*16)+j] = TPixels[(i*16)+j]->render(
+					xpos + ((mGlobalSettings.TileSize*mGlobalSettings.PaletteScale+2)*j),
+					ypos + ((mGlobalSettings.TileSize*mGlobalSettings.PaletteScale+2)*i),
+					mGlobalSettings.PaletteScale,true,true);
 		}
 	}
 


### PR DESCRIPTION
I noticed this on your screenshots to the X16 forum.  The palette was displayed inverted, contrary to how it's displayed everywhere else.  I don't believe anything but the display logic was incorrect, but the current program displays the palette like this on the tile editor:
```
 0 16 32 48 ...
 1 17 33 49 ...
 2 18 34 50 ...
...
```
This change modifies to display as:
```
 0  1  2  3 ...
16 17 18 19 ...
32 33 34 35 ...
...
```
I believe this is what was intended.