### PR TITLE
Fix build for systems who build SDL2 libs from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,30 @@
 cmake_minimum_required(VERSION 3.1)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+
 project(Tilemaped)
+
+find_package(SDL2 2.0.17 REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(SDL2_ttf REQUIRED)
 
 file(GLOB Tilemaped_SRC "*.cpp" ".h")
 
 add_executable(tilemaped ${Tilemaped_SRC})
 
-find_package(SDL2 REQUIRED)
+target_include_directories(tilemaped SYSTEM PUBLIC ${SDL2_INCLUDE_DIRS} ${SDL2_IMAGE_INCLUDE_DIRS} ${SDL2_TTF_INCLUDE_DIRS})
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	set(CMAKE_CXX_COMPILER "g++")
 	set(CMAKE_CXX_FLAGS "-std=c++17 -mwindows")
-	target_include_directories(tilemaped PUBLIC ${SDL2_INCLUDE_DIRS})
 	target_link_directories(tilemaped PUBLIC C:/msys64/mingw64/lib)
 	add_definitions(-Dmain=SDL_main)
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	set(CMAKE_CXX_COMPILER "g++")
-	target_include_directories(tilemaped PUBLIC . ${SDL2_INCLUDE_DIRS})
-endif()
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	set(CMAKE_CXX_FLAGS "-std=c++17")
-	target_link_libraries(tilemaped ${SDL2_LIBRARIES} SDL2_image SDL2_ttf)
+	target_link_libraries(tilemaped ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_TTF_LIBRARIES})
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/cmake/FindSDL2_image.cmake
+++ b/cmake/FindSDL2_image.cmake
@@ -1,0 +1,100 @@
+# Distributed under the OSI-approved BSD 3-Clause License. See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindSDL2_image
+# -------------
+#
+# Locate SDL2_image library
+#
+# This module defines:
+#
+# ::
+#
+# SDL2_IMAGE_LIBRARIES, the name of the library to link against
+# SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
+# SDL2_IMAGE_FOUND, if false, do not try to link against
+# SDL2_IMAGE_VERSION_STRING - human-readable string containing the
+# version of SDL2_image
+#
+#
+#
+# For backward compatibility the following variables are also set:
+#
+# ::
+#
+# SDL2IMAGE_LIBRARY (same value as SDL2_IMAGE_LIBRARIES)
+# SDL2IMAGE_INCLUDE_DIR (same value as SDL2_IMAGE_INCLUDE_DIRS)
+# SDL2IMAGE_FOUND (same value as SDL2_IMAGE_FOUND)
+#
+#
+#
+# $SDLDIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDLDIR used in building SDL.
+#
+# Created by Eric Wing. This was influenced by the FindSDL.cmake
+# module, but with modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+
+if(NOT SDL2_IMAGE_INCLUDE_DIR AND SDL2IMAGE_INCLUDE_DIR)
+  set(SDL2_IMAGE_INCLUDE_DIR ${SDL2IMAGE_INCLUDE_DIR} CACHE PATH "directory cache entry initialized from old variable name")
+endif()
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+    ${SDL2_DIR}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2 include
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+if(NOT SDL2_IMAGE_LIBRARY AND SDL2IMAGE_LIBRARY)
+  set(SDL2_IMAGE_LIBRARY ${SDL2IMAGE_LIBRARY} CACHE FILEPATH "file cache entry initialized from old variable name")
+endif()
+find_library(SDL2_IMAGE_LIBRARY
+  NAMES SDL2_image
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+    ${SDL2_DIR}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h" SDL2_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL2_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h" SDL2_IMAGE_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL2_IMAGE_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL2_image.h" SDL2_IMAGE_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL2_IMAGE_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_IMAGE_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MAJOR "${SDL2_IMAGE_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_IMAGE_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MINOR "${SDL2_IMAGE_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_IMAGE_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_PATCH "${SDL2_IMAGE_VERSION_PATCH_LINE}")
+  set(SDL2_IMAGE_VERSION_STRING ${SDL2_IMAGE_VERSION_MAJOR}.${SDL2_IMAGE_VERSION_MINOR}.${SDL2_IMAGE_VERSION_PATCH})
+  unset(SDL2_IMAGE_VERSION_MAJOR_LINE)
+  unset(SDL2_IMAGE_VERSION_MINOR_LINE)
+  unset(SDL2_IMAGE_VERSION_PATCH_LINE)
+  unset(SDL2_IMAGE_VERSION_MAJOR)
+  unset(SDL2_IMAGE_VERSION_MINOR)
+  unset(SDL2_IMAGE_VERSION_PATCH)
+endif()
+
+set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+set(SDL2_IMAGE_INCLUDE_DIRS ${SDL2_IMAGE_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_image
+                                  REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_IMAGE_VERSION_STRING)
+
+# for backward compatibility
+set(SDL2IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARIES})
+set(SDL2IMAGE_INCLUDE_DIR ${SDL2_IMAGE_INCLUDE_DIRS})
+set(SDL2IMAGE_FOUND ${SDL2_IMAGE_FOUND})
+
+mark_as_advanced(SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)

--- a/cmake/FindSDL2_ttf.cmake
+++ b/cmake/FindSDL2_ttf.cmake
@@ -1,0 +1,100 @@
+# Distributed under the OSI-approved BSD 3-Clause License. See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindSDL2_ttf
+# -------------
+#
+# Locate SDL2_ttf library
+#
+# This module defines:
+#
+# ::
+#
+# SDL2_TTF_LIBRARIES, the name of the library to link against
+# SDL2_TTF_INCLUDE_DIRS, where to find the headers
+# SDL2_TTF_FOUND, if false, do not try to link against
+# SDL2_TTF_VERSION_STRING - human-readable string containing the
+# version of SDL2_ttf
+#
+#
+#
+# For backward compatibility the following variables are also set:
+#
+# ::
+#
+# SDL2TTF_LIBRARY (same value as SDL2_TTF_LIBRARIES)
+# SDL2TTF_INCLUDE_DIR (same value as SDL2_TTF_INCLUDE_DIRS)
+# SDL2TTF_FOUND (same value as SDL2_TTF_FOUND)
+#
+#
+#
+# $SDLDIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDLDIR used in building SDL.
+#
+# Created by Eric Wing. This was influenced by the FindSDL.cmake
+# module, but with modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+
+if(NOT SDL2_TTF_INCLUDE_DIR AND SDL2TTF_INCLUDE_DIR)
+  set(SDL2_TTF_INCLUDE_DIR ${SDL2TTF_INCLUDE_DIR} CACHE PATH "directory cache entry initialized from old variable name")
+endif()
+find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+  HINTS
+    ENV SDL2TTFDIR
+    ENV SDL2DIR
+    ${SDL2_DIR}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2 include
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+if(NOT SDL2_TTF_LIBRARY AND SDL2TTF_LIBRARY)
+  set(SDL2_TTF_LIBRARY ${SDL2TTF_LIBRARY} CACHE FILEPATH "file cache entry initialized from old variable name")
+endif()
+find_library(SDL2_TTF_LIBRARY
+  NAMES SDL2_ttf
+  HINTS
+    ENV SDL2TTFDIR
+    ENV SDL2DIR
+    ${SDL2_DIR}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+)
+
+if(SDL2_TTF_INCLUDE_DIR AND EXISTS "${SDL2_TTF_INCLUDE_DIR}/SDL2_ttf.h")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL2_ttf.h" SDL2_TTF_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL2_TTF_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL2_ttf.h" SDL2_TTF_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL2_TTF_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL2_ttf.h" SDL2_TTF_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL2_TTF_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_TTF_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MAJOR "${SDL2_TTF_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_TTF_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MINOR "${SDL2_TTF_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL2_TTF_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_PATCH "${SDL2_TTF_VERSION_PATCH_LINE}")
+  set(SDL2_TTF_VERSION_STRING ${SDL2_TTF_VERSION_MAJOR}.${SDL2_TTF_VERSION_MINOR}.${SDL2_TTF_VERSION_PATCH})
+  unset(SDL2_TTF_VERSION_MAJOR_LINE)
+  unset(SDL2_TTF_VERSION_MINOR_LINE)
+  unset(SDL2_TTF_VERSION_PATCH_LINE)
+  unset(SDL2_TTF_VERSION_MAJOR)
+  unset(SDL2_TTF_VERSION_MINOR)
+  unset(SDL2_TTF_VERSION_PATCH)
+endif()
+
+set(SDL2_TTF_LIBRARIES ${SDL2_TTF_LIBRARY})
+set(SDL2_TTF_INCLUDE_DIRS ${SDL2_TTF_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_ttf
+                                  REQUIRED_VARS SDL2_TTF_LIBRARIES SDL2_TTF_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_TTF_VERSION_STRING)
+
+# for backward compatibility
+set(SDL2TTF_LIBRARY ${SDL2_TTF_LIBRARIES})
+set(SDL2TTF_INCLUDE_DIR ${SDL2_TTF_INCLUDE_DIRS})
+set(SDL2TTF_FOUND ${SDL2_TTF_FOUND})
+
+mark_as_advanced(SDL2_TTF_LIBRARY SDL2_TTF_INCLUDE_DIR)


### PR DESCRIPTION
Builds were failing when built-from-source versions of SDL2 libraries were used.  This is because building from scratch delivers the libraries to `/usr/local` instead of the system-managed libraries in `/usr`.  This fix for this is 2-fold.

First, we make sure the CMake can properly look up system configurations.  This is done by custom `*.cmake` files committed to this repo, as per this advice: https://trenki2.github.io/blog/2017/07/04/using-sdl2-image-with-cmake/

Next, we make sure that build dependencies expected to be system-level (not vendored or included in this repo) are included with `-isystem` instead of `-I`.  We also make sure that any `/usr/local` paths appear to the left of any `/usr` paths, since the search goes left to right.

I'm hoping these changes work on other systems as well, and I consolidated the call to `target_include_directories` for both Windows and Linux.  I didn't see a reason they should be different, unless the `SYSTEM` argument causes problems on Windows.  I also included custom `*.cmake` files for both SDL2_image and SDL2_ttf, since I believe that neither are included in the standard CMake distributions.